### PR TITLE
Fix convert_to_datetime missing return

### DIFF
--- a/finrl/meta/preprocessor/preprocessors.py
+++ b/finrl/meta/preprocessor/preprocessors.py
@@ -39,6 +39,7 @@ def convert_to_datetime(time):
     time_fmt = "%Y-%m-%dT%H:%M:%S"
     if isinstance(time, str):
         return datetime.datetime.strptime(time, time_fmt)
+    return time
 
 
 class GroupByScaler(BaseEstimator, TransformerMixin):


### PR DESCRIPTION
## Summary
- handle non-string input in `convert_to_datetime`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685645ececf48325bc925f798597c857